### PR TITLE
Create a Docker image for the service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: java
 jdk:
-  - openjdk6
   - openjdk7
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM openjdk:7-alpine
+
+MAINTAINER QMetric Group Ltd <no-reply@qmetric.com>
+
+RUN apk add --update mysql mysql-client && rm -f /var/cache/apk/*
+
+COPY target/hal-feed-server.jar /opt/hal-feed-server/hal-feed-server.jar
+COPY docker/config.yml /usr/local/config/hal-feed-server/server-config.yml
+
+COPY docker/entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+EXPOSE 8080 8081
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:7-alpine
 
-MAINTAINER QMetric Group Ltd <no-reply@qmetric.com>
+MAINTAINER QMetric Group Ltd
 
 RUN apk add --update mysql mysql-client && rm -f /var/cache/apk/*
 

--- a/README.md
+++ b/README.md
@@ -276,5 +276,5 @@ mvn -Pbuild-docker-image package
 This image contains an instance of MySQL, which is used for feed persistence. It exposes the main and admin Dropwizard ports, to run:
 
 ```bash
-docker run -p18080:8080 -p18081:8081 qmetric/hal-feed-server:$VERSION-embedded
+docker run -p18080:8080 -p18081:8081 hal-feed-server:$VERSION-embedded
 ``` 

--- a/README.md
+++ b/README.md
@@ -262,3 +262,19 @@ Retrieve metrics of server:
 Retrieve a JVM thread dump:
 
     GET: <serverhost>:<adminPort>/threads
+
+# Docker
+
+The intended use of the image is for local development and testing, it is not suitable for 'production' use.
+
+To build the 'embedded' Docker image for the service and install it locally:
+
+```bash
+mvn -Pbuild-docker-image package
+``` 
+
+This image contains an instance of MySQL, which is used for feed persistence. It exposes the main and admin Dropwizard ports, to run:
+
+```bash
+docker run -p18080:8080 -p18081:8081 qmetric/hal-feed-server:$VERSION-embedded
+``` 

--- a/docker/config.yml
+++ b/docker/config.yml
@@ -1,30 +1,7 @@
-publicBaseUrl: http://localhost:8080
-
 feedName: Test Feed
-
-# authentication:
-  # username: admin
-  # password: password
-
-# feedEntryLinks:
-  # - rel: other
-    # href: http://other.com
-  # - rel: other2
-    # href: http://other2.com/{nameOfSomePayloadAttr}
 
 defaultEntriesPerPage: 10
 
-# validation:
-  # Error if payload to publish does not contain the following mandatory attributes
-  # required:
-    # - customerId
-    # - customerName
-
-# hiddenPayloadAttributes:
-  # - customerId
-  # - customerName
-
-# Data source for feed persistence (only Mysql supported)
 databaseConfiguration:
   driverClass: com.mysql.jdbc.Driver
   user: usr

--- a/docker/config.yml
+++ b/docker/config.yml
@@ -1,0 +1,49 @@
+publicBaseUrl: http://localhost:8080
+
+feedName: Test Feed
+
+# authentication:
+  # username: admin
+  # password: password
+
+# feedEntryLinks:
+  # - rel: other
+    # href: http://other.com
+  # - rel: other2
+    # href: http://other2.com/{nameOfSomePayloadAttr}
+
+defaultEntriesPerPage: 10
+
+# validation:
+  # Error if payload to publish does not contain the following mandatory attributes
+  # required:
+    # - customerId
+    # - customerName
+
+# hiddenPayloadAttributes:
+  # - customerId
+  # - customerName
+
+# Data source for feed persistence (only Mysql supported)
+databaseConfiguration:
+  driverClass: com.mysql.jdbc.Driver
+  user: usr
+  password: pwd
+  url: jdbc:mysql://localhost:3306/feed_db
+  validationQuery: select 1
+
+# Local server HTTP configuration
+http:
+  port: 8080
+  adminPort: 8081
+  requestLog:
+    timeZone: GB
+    console:
+      enabled: true
+
+# Logging configuration
+logging:
+  level: INFO
+  console:
+    enabled: true
+    timeZone: GB

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+set -e
+
+print_message() {
+    echo
+    echo "*********************************"
+    echo "* $1"
+    echo "*********************************"
+    echo
+}
+
+DATA_DIR="/var/lib/mysql"
+
+print_message 'Initializing MySQL...'
+
+if [ ! -d "$DATA_DIR/mysql" ]; then
+    mkdir -p "$DATA_DIR"
+    chown -R mysql:mysql "$DATA_DIR"
+
+    mysql_install_db --user=mysql --datadir="$DATA_DIR" --rpm
+fi
+
+mysqld_safe --nowatch
+
+print_message 'Waiting for MySQL to start...'
+
+# wait until mysql is available...
+while ! echo exit | nc 127.0.0.1 3306 </dev/null >/dev/null; do sleep 5; done
+
+print_message 'Creating the Feed database...'
+
+mysql -uroot -h 127.0.0.1 <<-EOF
+   CREATE DATABASE IF NOT EXISTS feed_db;
+   GRANT ALL ON feed_db.* TO 'usr'@'localhost' IDENTIFIED BY 'pwd';
+EOF
+
+print_message 'Starting the service...'
+
+java -jar /opt/hal-feed-server/hal-feed-server.jar

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -18,7 +18,7 @@ if [ ! -d "$DATA_DIR/mysql" ]; then
     mkdir -p "$DATA_DIR"
     chown -R mysql:mysql "$DATA_DIR"
 
-    mysql_install_db --user=mysql --datadir="$DATA_DIR" --rpm
+    mysql_install_db --user=mysql --datadir="$DATA_DIR"
 fi
 
 mysqld_safe --nowatch

--- a/pom.xml
+++ b/pom.xml
@@ -240,6 +240,24 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>dockerfile-maven-plugin</artifactId>
+                <version>1.3.5</version>
+                <executions>
+                    <execution>
+                        <id>default</id>
+                        <goals>
+                            <goal>build</goal>
+                            <!-- <goal>push</goal> -->
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <repository>qmetric/hal-feed-server</repository>
+                    <tag>${project.version}-embedded</tag>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -240,25 +240,35 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
-                <version>1.3.5</version>
-                <executions>
-                    <execution>
-                        <id>default</id>
-                        <goals>
-                            <goal>build</goal>
-                            <!-- <goal>push</goal> -->
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <repository>qmetric/hal-feed-server</repository>
-                    <tag>${project.version}-embedded</tag>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>build-docker-image</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.spotify</groupId>
+                        <artifactId>dockerfile-maven-plugin</artifactId>
+                        <version>1.3.5</version>
+                        <executions>
+                            <execution>
+                                <id>default</id>
+                                <goals>
+                                    <goal>build</goal>
+                                    <!-- <goal>push</goal> -->
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <repository>qmetric/hal-feed-server</repository>
+                            <tag>${project.version}-embedded</tag>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -262,7 +262,7 @@
                             </execution>
                         </executions>
                         <configuration>
-                            <repository>qmetric/hal-feed-server</repository>
+                            <repository>hal-feed-server</repository>
                             <tag>${project.version}-embedded</tag>
                         </configuration>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
         <dependency>
             <groupId>org.spockframework</groupId>
             <artifactId>spock-core</artifactId>
-            <version>0.7-groovy-2.0</version>
+            <version>1.1-groovy-2.4</version>
             <scope>test</scope>
         </dependency>
 
@@ -225,16 +225,13 @@
             </plugin>
 
             <plugin>
-                <groupId>org.codehaus.gmaven</groupId>
-                <artifactId>gmaven-plugin</artifactId>
-                <version>1.4</version>
-                <configuration>
-                    <providerSelection>2.0</providerSelection>
-                    <source />
-                </configuration>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
+                <version>1.5</version>
                 <executions>
                     <execution>
                         <goals>
+                            <goal>compile</goal>
                             <goal>testCompile</goal>
                         </goals>
                     </execution>

--- a/src/main/java/com/qmetric/feed/app/HalFeedRepresentationFactory.java
+++ b/src/main/java/com/qmetric/feed/app/HalFeedRepresentationFactory.java
@@ -60,17 +60,17 @@ public class HalFeedRepresentationFactory implements FeedRepresentationFactory<R
         this.hiddenPayloadAttributes = hiddenPayloadAttributes;
     }
 
-    @Override public Representation format(final URI feedURI, final FeedEntries entries)
+    @Override public Representation format(final URI feedUri, final FeedEntries entries)
     {
-        final Representation hal = representationFactory.newRepresentation(feedURI);
+        final Representation hal = representationFactory.newRepresentation(feedUri);
 
         hal.withProperty(FEED_NAME_KEY, feedName);
 
-        includeNavigationalLinks(feedURI, entries, hal);
+        includeNavigationalLinks(feedUri, entries, hal);
 
         for (final FeedEntry entry : entries.all())
         {
-            final Representation entryHal = formatExcludingPayloadAttributes(feedURI, entry);
+            final Representation entryHal = formatExcludingPayloadAttributes(feedUri, entry);
 
             includePayloadAttributes(entryHal, filterKeys(entry.payload.attributes, new Predicate<String>()
             {
@@ -86,9 +86,9 @@ public class HalFeedRepresentationFactory implements FeedRepresentationFactory<R
         return hal;
     }
 
-    @Override public Representation format(final URI feedURI, final FeedEntry entry)
+    @Override public Representation format(final URI feedUri, final FeedEntry entry)
     {
-        final Representation hal = formatExcludingPayloadAttributes(feedURI, entry);
+        final Representation hal = formatExcludingPayloadAttributes(feedUri, entry);
 
         includePayloadAttributes(hal, entry.payload.attributes);
 
@@ -103,22 +103,22 @@ public class HalFeedRepresentationFactory implements FeedRepresentationFactory<R
         }
     }
 
-    private void includeNavigationalLinks(URI feedURI, final FeedEntries entries, final Representation hal)
+    private void includeNavigationalLinks(URI feedUri, final FeedEntries entries, final Representation hal)
     {
         if (entries.laterExists)
         {
-            hal.withLink(PREVIOUS_LINK_RELATION, String.format("%s?laterThan=%s", feedURI, entries.first().get().id));
+            hal.withLink(PREVIOUS_LINK_RELATION, String.format("%s?laterThan=%s", feedUri, entries.first().get().id));
         }
 
         if (entries.earlierExists)
         {
-            hal.withLink(NEXT_LINK_RELATION, String.format("%s?earlierThan=%s", feedURI, entries.last().get().id));
+            hal.withLink(NEXT_LINK_RELATION, String.format("%s?earlierThan=%s", feedUri, entries.last().get().id));
         }
     }
 
-    private Representation formatExcludingPayloadAttributes(URI feedURI, final FeedEntry entry)
+    private Representation formatExcludingPayloadAttributes(URI feedUri, final FeedEntry entry)
     {
-        final Representation hal = representationFactory.newRepresentation(selfLinkForEntry(feedURI, entry));
+        final Representation hal = representationFactory.newRepresentation(selfLinkForEntry(feedUri, entry));
 
         includeAdditionalLinks(entry, hal, links.additionalLinksForFeedEntry());
 
@@ -129,9 +129,9 @@ public class HalFeedRepresentationFactory implements FeedRepresentationFactory<R
         return hal;
     }
 
-    private String selfLinkForEntry(URI feedURI, final FeedEntry feedEntry)
+    private String selfLinkForEntry(URI feedUri, final FeedEntry feedEntry)
     {
-        return String.format("%s/%s", feedURI, feedEntry.id);
+        return String.format("%s/%s", feedUri, feedEntry.id);
     }
 
     private void includeAdditionalLinks(final FeedEntry feedEntry, final Representation representation, final Collection<FeedEntryLink> links)

--- a/src/main/java/com/qmetric/feed/app/Main.java
+++ b/src/main/java/com/qmetric/feed/app/Main.java
@@ -27,8 +27,6 @@ import com.yammer.dropwizard.db.ManagedDataSourceFactory;
 import com.yammer.dropwizard.jdbi.DBIFactory;
 import com.yammer.dropwizard.json.ObjectMapperFactory;
 
-import java.net.URI;
-
 public class Main extends Service<ServerConfiguration>
 {
     private static final String DEFAULT_CONF_FILE = "/usr/local/config/hal-feed-server/server-config.yml";
@@ -56,12 +54,12 @@ public class Main extends Service<ServerConfiguration>
         final FeedStore feedStore = initFeedStore(environment, configuration.getDatabaseConfiguration());
 
         final FeedRepresentationFactory<Representation> feedResponseFactory =
-                new HalFeedRepresentationFactory(configuration.getFeedName(), new URI(configuration.getFeedSelfLink()), configuration.getFeedEntryLinks(),
+                new HalFeedRepresentationFactory(configuration.getFeedName(), configuration.getFeedEntryLinks(),
                                                  configuration.getHiddenPayloadAttributes());
 
         environment.addResource(new PingResource());
         environment.addResource(new HealthCheckResource(configureHealthChecks(feedStore)));
-        environment.addResource(new FeedResource(new Feed(feedStore, configuration.getPayloadValidationRules()), feedResponseFactory, configuration.getDefaultEntriesPerPage()));
+        environment.addResource(new FeedResource(configuration.getPublicBaseUrl(), new Feed(feedStore, configuration.getPayloadValidationRules()), feedResponseFactory, configuration.getDefaultEntriesPerPage()));
     }
 
     private HealthCheckRegistry configureHealthChecks(final FeedStore feedStore)

--- a/src/main/java/com/qmetric/feed/app/ServerConfiguration.java
+++ b/src/main/java/com/qmetric/feed/app/ServerConfiguration.java
@@ -2,7 +2,6 @@ package com.qmetric.feed.app;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
-import com.qmetric.feed.app.resource.FeedResource;
 import com.qmetric.feed.domain.FeedEntryLink;
 import com.qmetric.feed.domain.HiddenPayloadAttributes;
 import com.qmetric.feed.domain.Links;
@@ -16,7 +15,6 @@ import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-
 import java.util.Collection;
 import java.util.Collections;
 
@@ -24,7 +22,7 @@ import static java.util.Collections.emptyList;
 
 public class ServerConfiguration extends Configuration
 {
-    @NotEmpty @JsonProperty
+    @JsonProperty
     private String publicBaseUrl;
 
     @NotEmpty @JsonProperty
@@ -48,9 +46,9 @@ public class ServerConfiguration extends Configuration
     @Valid @NotNull @JsonProperty
     private DatabaseConfiguration databaseConfiguration = new DatabaseConfiguration();
 
-    public String getFeedSelfLink()
+    public String getPublicBaseUrl()
     {
-        return publicBaseUrl + FeedResource.CONTEXT;
+        return publicBaseUrl;
     }
 
     public Links getFeedEntryLinks()

--- a/src/main/java/com/qmetric/feed/app/resource/FeedResource.java
+++ b/src/main/java/com/qmetric/feed/app/resource/FeedResource.java
@@ -58,7 +58,7 @@ public class FeedResource
         this.feed = feed;
         this.feedRepresentationFactory = feedRepresentationFactory;
         this.defaultEntriesPerPage = defaultEntriesPerPage;
-        this.feedURI = toFeedURI(publicBaseUrl);
+        this.feedURI = toFeedUri(publicBaseUrl);
     }
 
     @GET @Timed
@@ -67,9 +67,9 @@ public class FeedResource
     {
         try
         {
-            return ok(feedRepresentationFactory
-                              .format(resolveFeedURI(uriInfo), feed.retrieveBy(new FeedRestrictionCriteria(new Filter(toOptionalId(earlierThan), toOptionalId(laterThan)), limit.or(defaultEntriesPerPage))))
-                              .toString(HAL_JSON)).build();
+            return ok(feedRepresentationFactory.format(resolveFeedURI(uriInfo), feed.retrieveBy(new FeedRestrictionCriteria(new Filter(toOptionalId(earlierThan), toOptionalId(laterThan)), limit.or(defaultEntriesPerPage))))
+                    .toString(HAL_JSON))
+                    .build();
         }
         catch (IllegalArgumentException e)
         {
@@ -84,7 +84,10 @@ public class FeedResource
 
         if (feedEntry.isPresent())
         {
-            return ok(feedRepresentationFactory.format(resolveFeedURI(uriInfo), feedEntry.get()).toString(HAL_JSON)).build();
+            return ok(feedRepresentationFactory.format(
+                    resolveFeedURI(uriInfo), feedEntry.get())
+                    .toString(HAL_JSON))
+                    .build();
         }
         else
         {
@@ -99,7 +102,9 @@ public class FeedResource
         {
             final Representation hal = feedRepresentationFactory.format(resolveFeedURI(uriInfo), feed.publish(payload));
 
-            return created(new URI(hal.getResourceLink().getHref())).entity(hal.toString(HAL_JSON)).build();
+            return created(new URI(hal.getResourceLink().getHref()))
+                    .entity(hal.toString(HAL_JSON))
+                    .build();
         }
         catch (IllegalArgumentException e)
         {
@@ -124,7 +129,7 @@ public class FeedResource
             : uriInfo.getBaseUriBuilder().path(FeedResource.CONTEXT).build();
     }
 
-    private URI toFeedURI(String publicBaseUrl) {
+    private URI toFeedUri(String publicBaseUrl) {
         try {
             if (publicBaseUrl == null) {
                 LOGGER.info("publicBaseUrl is not set, 'self' will be determined through the HTTP-request");

--- a/src/main/java/com/qmetric/feed/domain/FeedRepresentationFactory.java
+++ b/src/main/java/com/qmetric/feed/domain/FeedRepresentationFactory.java
@@ -1,8 +1,10 @@
 package com.qmetric.feed.domain;
 
+import java.net.URI;
+
 public interface FeedRepresentationFactory<T>
 {
-    T format(FeedEntries entries);
+    T format(URI feedUri, FeedEntries entries);
 
-    T format(FeedEntry entry);
+    T format(URI feedUri, FeedEntry entry);
 }

--- a/src/test/groovy/com/qmetric/feed/app/HalFeedRepresentationFactoryTest.groovy
+++ b/src/test/groovy/com/qmetric/feed/app/HalFeedRepresentationFactoryTest.groovy
@@ -23,11 +23,11 @@ class HalFeedRepresentationFactoryTest extends Specification {
     def "should return hal+json representation of entries"()
     {
         given:
-        final factory = new HalFeedRepresentationFactory(feedName, feedUri, NO_LINKS, HiddenPayloadAttributes.NONE)
+        final factory = new HalFeedRepresentationFactory(feedName, NO_LINKS, HiddenPayloadAttributes.NONE)
         final entries = new FeedEntries([entry2, entry1])
 
         when:
-        final hal = factory.format(entries)
+        final hal = factory.format(feedUri, entries)
 
         then:
         jsonSlurper.parseText(hal.toString(HAL_JSON)) == jsonFrom('/feed-samples/expectedHalWithMultipleEntries.json')
@@ -36,11 +36,11 @@ class HalFeedRepresentationFactoryTest extends Specification {
     def "should return hal+json representation of entries with custom links"()
     {
         given:
-        final factory = new HalFeedRepresentationFactory(feedName, feedUri, new Links([new FeedEntryLink("someLink", "http://other"), new FeedEntryLink("someLinkWithNamedParam", "http://other/{someId}")]), HiddenPayloadAttributes.NONE)
+        final factory = new HalFeedRepresentationFactory(feedName, new Links([new FeedEntryLink("someLink", "http://other"), new FeedEntryLink("someLinkWithNamedParam", "http://other/{someId}")]), HiddenPayloadAttributes.NONE)
         final entries = new FeedEntries([entry2, entry1])
 
         when:
-        final hal = factory.format(entries)
+        final hal = factory.format(feedUri, entries)
 
         then:
         jsonSlurper.parseText(hal.toString(HAL_JSON)) == jsonFrom('/feed-samples/expectedHalWithMultipleEntriesWithCustomLinks.json')
@@ -49,11 +49,11 @@ class HalFeedRepresentationFactoryTest extends Specification {
     def "should return hal+json representation of entry"()
     {
         given:
-        final factory = new HalFeedRepresentationFactory(feedName, feedUri, NO_LINKS, HiddenPayloadAttributes.NONE)
+        final factory = new HalFeedRepresentationFactory(feedName, NO_LINKS, HiddenPayloadAttributes.NONE)
         final entry = entry1
 
         when:
-        final hal = factory.format(entry)
+        final hal = factory.format(feedUri, entry)
 
         then:
         jsonSlurper.parseText(hal.toString(HAL_JSON)) == jsonFrom('/feed-samples/expectedHalWithSingleEntry.json')
@@ -62,11 +62,11 @@ class HalFeedRepresentationFactoryTest extends Specification {
     def "should return hal+json representation of entry with complex payload"()
     {
         given:
-        final factory = new HalFeedRepresentationFactory(feedName, feedUri, NO_LINKS, HiddenPayloadAttributes.NONE)
+        final factory = new HalFeedRepresentationFactory(feedName, NO_LINKS, HiddenPayloadAttributes.NONE)
         final entry = new FeedEntry(Id.of("1"), new DateTime(2013, 5, 13, 11, 2, 32), new Payload(["nested": ["someId": "aaaa"], "arr": ["a", "b", "c"]]))
 
         when:
-        final hal = factory.format(entry)
+        final hal = factory.format(feedUri, entry)
 
         then:
         jsonSlurper.parseText(hal.toString(HAL_JSON)) == jsonFrom('/feed-samples/expectedHalWithSingleEntryWithComplexPayload.json')
@@ -75,11 +75,11 @@ class HalFeedRepresentationFactoryTest extends Specification {
     def "should return hal+json representation of entry with custom links"()
     {
         given:
-        final factory = new HalFeedRepresentationFactory(feedName, feedUri, new Links([new FeedEntryLink("someLink", "http://other"), new FeedEntryLink("someLinkWithNamedParam", "http://other/{someId}/{someNum}")]), HiddenPayloadAttributes.NONE)
+        final factory = new HalFeedRepresentationFactory(feedName, new Links([new FeedEntryLink("someLink", "http://other"), new FeedEntryLink("someLinkWithNamedParam", "http://other/{someId}/{someNum}")]), HiddenPayloadAttributes.NONE)
         final entry = new FeedEntry(Id.of("1"), new DateTime(2013, 5, 13, 11, 2, 32), new Payload(["someId": "s 12/34", "someNum": 1234]))
 
         when:
-        final hal = factory.format(entry)
+        final hal = factory.format(feedUri, entry)
 
         then:
         jsonSlurper.parseText(hal.toString(HAL_JSON)) == jsonFrom('/feed-samples/expectedHalWithSingleEntryWithCustomLinks.json')
@@ -88,11 +88,11 @@ class HalFeedRepresentationFactoryTest extends Specification {
     def "should apply templated attr in returned hal+json representation with custom link with unresolved named parameter"()
     {
         given:
-        final factory = new HalFeedRepresentationFactory(feedName, feedUri, new Links([new FeedEntryLink("someLink", "http://other/{unresolved}")]), HiddenPayloadAttributes.NONE)
+        final factory = new HalFeedRepresentationFactory(feedName, new Links([new FeedEntryLink("someLink", "http://other/{unresolved}")]), HiddenPayloadAttributes.NONE)
         final entry = new FeedEntry(Id.of("1"), new DateTime(2013, 5, 13, 11, 2, 32), new Payload([:]))
 
         when:
-        final hal = factory.format(entry)
+        final hal = factory.format(feedUri, entry)
 
         then:
         jsonSlurper.parseText(hal.toString(HAL_JSON)) == jsonFrom('/feed-samples/expectedHalWithTemplatedCustomLink.json')
@@ -101,11 +101,11 @@ class HalFeedRepresentationFactoryTest extends Specification {
     def "should return hal+json representation for page of entries with navigational links"()
     {
         given:
-        final factory = new HalFeedRepresentationFactory(feedName, feedUri, NO_LINKS, HiddenPayloadAttributes.NONE)
+        final factory = new HalFeedRepresentationFactory(feedName, NO_LINKS, HiddenPayloadAttributes.NONE)
         final entries = new FeedEntries([entry2, entry1], true, true)
 
         when:
-        final hal = factory.format(entries)
+        final hal = factory.format(feedUri, entries)
 
         then:
         jsonSlurper.parseText(hal.toString(HAL_JSON)) == jsonFrom('/feed-samples/expectedHalWithEntriesWithNavigationalLinks.json')
@@ -114,11 +114,11 @@ class HalFeedRepresentationFactoryTest extends Specification {
     def "should never hide payload attributes for representation of single entry"()
     {
         given:
-        final factory = new HalFeedRepresentationFactory(feedName, feedUri, NO_LINKS, new HiddenPayloadAttributes(["someId", "value"]))
+        final factory = new HalFeedRepresentationFactory(feedName, NO_LINKS, new HiddenPayloadAttributes(["someId", "value"]))
         final entry = entry1
 
         when:
-        final hal = factory.format(entry)
+        final hal = factory.format(feedUri, entry)
 
         then:
         jsonSlurper.parseText(hal.toString(HAL_JSON)) == jsonFrom('/feed-samples/expectedHalWithSingleEntry.json')
@@ -127,11 +127,11 @@ class HalFeedRepresentationFactoryTest extends Specification {
     def "should hide payload attributes for feed representation"()
     {
         given:
-        final factory = new HalFeedRepresentationFactory(feedName, feedUri, NO_LINKS, new HiddenPayloadAttributes(["value"]))
+        final factory = new HalFeedRepresentationFactory(feedName, NO_LINKS, new HiddenPayloadAttributes(["value"]))
         final entries = new FeedEntries([entry2, entry1])
 
         when:
-        final hal = factory.format(entries)
+        final hal = factory.format(feedUri, entries)
 
         then:
         jsonSlurper.parseText(hal.toString(HAL_JSON)) == jsonFrom('/feed-samples/expectedHalWithEntriesWithHiddenAttributes.json')

--- a/src/test/groovy/com/qmetric/feed/app/ServerConfigurationTest.groovy
+++ b/src/test/groovy/com/qmetric/feed/app/ServerConfigurationTest.groovy
@@ -16,7 +16,7 @@ class ServerConfigurationTest extends Specification {
         final config = loadConfig("/config-samples/test-full-server-config.yml")
 
         then:
-        config.feedSelfLink == 'http://www.domain.com/feed'
+        config.publicBaseUrl == 'http://www.domain.com'
         config.feedName == 'Test feed'
         newArrayList(config.feedEntryLinks.additionalLinksForFeedEntry()) == [new FeedEntryLink("other", 'http://other.com/feed'), new FeedEntryLink("other2", 'http://other2.com/feed')]
         config.getDefaultEntriesPerPage() == 20
@@ -31,7 +31,6 @@ class ServerConfigurationTest extends Specification {
         final config = loadConfig("/config-samples/test-minimal-server-config.yml")
 
         then:
-        config.feedSelfLink == 'http://www.domain.com/feed'
         config.feedName == 'Test feed'
         config.feedEntryLinks.additionalLinksForFeedEntry().isEmpty()
         config.getDefaultEntriesPerPage() == 10

--- a/src/test/groovy/com/qmetric/feed/app/resource/FeedResourceTest.groovy
+++ b/src/test/groovy/com/qmetric/feed/app/resource/FeedResourceTest.groovy
@@ -33,13 +33,13 @@ class FeedResourceTest extends Specification {
 
     final link = Mock(Link)
 
-    final feedResource = new FeedResource(feed, feedRepresentationFactory, 10)
+    final feedResource = new FeedResource('http://localhost:8080', feed, feedRepresentationFactory, 10)
 
     def setup()
     {
         representation.toString(HAL_JSON) >> responseBody
-        feedRepresentationFactory.format(feedEntry) >> representation
-        feedRepresentationFactory.format(entries) >> representation
+        feedRepresentationFactory.format(_ as URI, feedEntry) >> representation
+        feedRepresentationFactory.format(_ as URI, entries) >> representation
     }
 
     def "should return 201 with response body representation of published entry"()
@@ -50,7 +50,7 @@ class FeedResourceTest extends Specification {
         representation.getResourceLink() >> link
 
         when:
-        final response = feedResource.postEntry(null, feedEntry.payload)
+        final response = feedResource.postEntry(null, null, feedEntry.payload)
 
         then:
         response.entity == responseBody
@@ -64,7 +64,7 @@ class FeedResourceTest extends Specification {
         feed.publish(feedEntry.payload) >> { throw new IllegalArgumentException("Illegal argument") }
 
         when:
-        final response = feedResource.postEntry(null, feedEntry.payload)
+        final response = feedResource.postEntry(null, null, feedEntry.payload)
 
         then:
         response.entity == "Illegal argument"
@@ -77,7 +77,7 @@ class FeedResourceTest extends Specification {
         feed.retrieveBy(feedEntry.id) >> Optional.of(feedEntry)
 
         when:
-        final response = feedResource.getEntry(null, feedEntry.id.toString())
+        final response = feedResource.getEntry(null, null, feedEntry.id.toString())
 
         then:
         response.entity == "response body"
@@ -90,7 +90,7 @@ class FeedResourceTest extends Specification {
         feed.retrieveBy(feedEntry.id) >> Optional.absent()
 
         when:
-        final response = feedResource.getEntry(null, feedEntry.id.toString())
+        final response = feedResource.getEntry(null, null, feedEntry.id.toString())
 
         then:
         response.status == 404
@@ -110,7 +110,7 @@ class FeedResourceTest extends Specification {
         }
 
         when:
-        final response = feedResource.getPage(null, optionalIdToOptionalStr(criteria.filter.earlierThan), optionalIdToOptionalStr(criteria.filter.laterThan), Optional.of(criteria.limit))
+        final response = feedResource.getPage(null, null, optionalIdToOptionalStr(criteria.filter.earlierThan), optionalIdToOptionalStr(criteria.filter.laterThan), Optional.of(criteria.limit))
 
         then:
         response.status == expectedStatus

--- a/src/test/resources/config-samples/test-minimal-server-config.yml
+++ b/src/test/resources/config-samples/test-minimal-server-config.yml
@@ -1,5 +1,3 @@
-publicBaseUrl: http://www.domain.com
-
 feedName: Test feed
 
 databaseConfiguration:


### PR DESCRIPTION
I wanted to make the server easier to run locally and, potentially, for testing with other services. Containerization was a natural solution for this.

The build can now optionally create a Docker image which runs the hal-feed-server with an included MySQL instance. This image can be built by activating the `build-docker-image` profile - no remote publishing occurs.

A small change was required to let the server work inside a container. The `publicBaseUrl` configuration property is now optional, when it is unset the host is obtained from http requests to allow links in the feed to be constructed correctly.